### PR TITLE
Support Drush 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Allows you to get the complete picture of a site schema, to use for CI for example",
     "type": "drupal-drush",
     "require": {
-        "drush/drush": "~9||~10"
+        "drush/drush": "~9||~10||~11"
     },
     "license": "GPL-2.0+",
     "authors": [],


### PR DESCRIPTION
According to the [release notes](https://github.com/drush-ops/drush/releases/tag/11.0.0), there are no changes to the command API so no other changes should be required.