### PR TITLE
Add drush 13.x as an acceptable version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Allows you to get the complete picture of a site schema, to use for CI for example",
     "type": "drupal-drush",
     "require": {
-        "drush/drush": "~9 || ~10 || ~11 || ~12"
+        "drush/drush": "~9 || ~10 || ~11 || ~12 || ~13"
     },
     "license": "GPL-2.0-or-later",
     "authors": [],


### PR DESCRIPTION
I am building a new project that uses drush 13.

The command seems to still work just fine.